### PR TITLE
bump PHP requirements to allow from 7.1 or ~8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "FrankVanHest\\DnsLookup\\": "tests/"
+      "FrankVanHest\\DnsLookup\\Tests\\": "tests/"
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     }
   ],
   "require": {
-    "php": "^7.1"
+    "php": "^7.1 || ~8"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.2"
+    "phpunit/phpunit": "^7.2 || ~9"
   },
   "support": {
     "issues": "https://github.com/frankvanhest/dns-lookup/issues",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,6 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.2/phpunit.xsd"
          bootstrap="vendor/autoload.php"
-         forceCoversAnnotation="true"
          beStrictAboutCoversAnnotation="true"
          beStrictAboutOutputDuringTests="true"
          beStrictAboutTodoAnnotatedTests="true"

--- a/tests/DnsRecordTest.php
+++ b/tests/DnsRecordTest.php
@@ -27,7 +27,7 @@ class DnsRecordTest extends TestCase
      *
      * @return DnsRecord
      */
-    public function testCanBeContructedWithPrio(): DnsRecord
+    public function testCanBeConstructedWithPrio(): DnsRecord
     {
         $dnsRecord = new DnsRecord(
             self::RECORD_NAME, self::RECORD_TYPE, self::RECORD_VALUE, self::RECORD_TTL, self::RECORD_PRIO
@@ -53,8 +53,7 @@ class DnsRecordTest extends TestCase
     /**
      * The class should be immutable
      *
-     * @depends testCanBeContructedWithPrio
-     * @expectedException \RuntimeException
+     * @depends testCanBeConstructedWithPrio
      *
      * @param DnsRecord $dnsRecord
      *
@@ -62,14 +61,14 @@ class DnsRecordTest extends TestCase
      */
     public function testObjectIsImmutableWhenSettingProperty(DnsRecord $dnsRecord): void
     {
+        $this->expectException(\RuntimeException::class);
         $dnsRecord->dynamic = 'magic';
     }
 
     /**
      * The class should be immutable
      *
-     * @depends testCanBeContructedWithPrio
-     * @expectedException \RuntimeException
+     * @depends testCanBeConstructedWithPrio
      *
      * @param DnsRecord $dnsRecord
      *
@@ -77,13 +76,14 @@ class DnsRecordTest extends TestCase
      */
     public function testObjectIsImmutableWhenUnSettingProperty(DnsRecord $dnsRecord): void
     {
+        $this->expectException(\RuntimeException::class);
         unset($dnsRecord->dynamic);
     }
 
     /**
      * All the properties should be the same as given when constructing the instance
      *
-     * @depends testCanBeContructedWithPrio
+     * @depends testCanBeConstructedWithPrio
      *
      * @param DnsRecord $dnsRecord
      *


### PR DESCRIPTION
Validated tests against PHP 8 and phpunit ~9. 

```
Runtime:       PHP 8.0.10
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!

RRRRRRRRRRRRRRRRRRRRRRRRRSSS                                      28 / 28 (100%)

Time: 00:01.030, Memory: 6.00 MB

There were 25 risky tests:

1) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testCanBeConstructedWithoutNameserver
This test does not have a @covers annotation but is expected to have one

2) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testCanBeConstructedWithNameserver
This test does not have a @covers annotation but is expected to have one

3) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #0 ('A')
This test does not have a @covers annotation but is expected to have one

4) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #1 ('AAAA')
This test does not have a @covers annotation but is expected to have one

5) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #2 ('CAA')
This test does not have a @covers annotation but is expected to have one

6) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #3 ('CDS')
This test does not have a @covers annotation but is expected to have one

7) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #4 ('CERT')
This test does not have a @covers annotation but is expected to have one

8) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #5 ('CERT')
This test does not have a @covers annotation but is expected to have one

9) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #6 ('CNAME')
This test does not have a @covers annotation but is expected to have one

10) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #7 ('DNSKEY')
This test does not have a @covers annotation but is expected to have one

11) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #8 ('DS')
This test does not have a @covers annotation but is expected to have one

12) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #9 ('HINFO')
This test does not have a @covers annotation but is expected to have one

13) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #10 ('LOC')
This test does not have a @covers annotation but is expected to have one

14) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #11 ('MX')
This test does not have a @covers annotation but is expected to have one

15) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #12 ('NAPTR')
This test does not have a @covers annotation but is expected to have one

16) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #13 ('NS')
This test does not have a @covers annotation but is expected to have one

17) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #14 ('PTR')
This test does not have a @covers annotation but is expected to have one

18) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #15 ('SOA')
This test does not have a @covers annotation but is expected to have one

19) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #16 ('SRV')
This test does not have a @covers annotation but is expected to have one

20) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #17 ('SSHFP')
This test does not have a @covers annotation but is expected to have one

21) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #18 ('TLSA')
This test does not have a @covers annotation but is expected to have one

22) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetRecordsByType with data set #19 ('TXT')
This test does not have a @covers annotation but is expected to have one

23) FrankVanHest\DnsLookup\Tests\DnsLookupTest::testGetAllRecords
This test does not have a @covers annotation but is expected to have one

24) FrankVanHest\DnsLookup\Tests\DnsRecordTest::testCanBeContructedWithPrio
This test does not have a @covers annotation but is expected to have one

25) FrankVanHest\DnsLookup\Tests\DnsRecordTest::testCanBeContructedWithoutPrio
This test does not have a @covers annotation but is expected to have one

--

There were 3 skipped tests:

1) FrankVanHest\DnsLookup\Tests\DnsRecordTest::testObjectIsImmutableWhenSettingProperty
This test depends on "FrankVanHest\DnsLookup\Tests\DnsRecordTest::testCanBeContructedWithPrio" to pass.

2) FrankVanHest\DnsLookup\Tests\DnsRecordTest::testObjectIsImmutableWhenUnSettingProperty
This test depends on "FrankVanHest\DnsLookup\Tests\DnsRecordTest::testCanBeContructedWithPrio" to pass.

3) FrankVanHest\DnsLookup\Tests\DnsRecordTest::testPropertiesShouldBeSameAsGivenInConstructor
This test depends on "FrankVanHest\DnsLookup\Tests\DnsRecordTest::testCanBeContructedWithPrio" to pass.

OK, but incomplete, skipped, or risky tests!
Tests: 28, Assertions: 45, Skipped: 3, Risky: 25.

```