### PR TITLE
Update README.md: Adding `dig` info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DNS Lookup
-Simple library to retrieve DNS records with default OS resolver or specific nameserver.
+Simple library to retrieve DNS records using the OS's `dig` command (with default resolver or specific nameserver).
 
 ## Install
 Simple, just use composer


### PR DESCRIPTION
Info is taken from looking at the source code - I hope I didn't miss anything ;-)

Question: Why are you preferring `dig` over PHP's DNS functions, like `checkdnsrr()` or `dns_get_record()`?